### PR TITLE
Use the correct label formats for Kubernetes

### DIFF
--- a/charts/qtap/Chart.yaml
+++ b/charts/qtap/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: 0.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/qtap/templates/deployment.yaml
+++ b/charts/qtap/templates/deployment.yaml
@@ -47,13 +47,13 @@ spec:
                   name: token
                   key: token
           ports:
-            - name: tcpService
+            - name: tcp-service
               containerPort: {{ .Values.service.tcpPort }}
               protocol: TCP
-            - name: httpService
+            - name: http-service
               containerPort: {{ .Values.service.httpPort }}
               protocol: TCP
-            - name: httpsService
+            - name: https-service
               containerPort: {{ .Values.service.httpsPort }}
               protocol: TCP
             - name: status

--- a/charts/qtap/templates/service.yaml
+++ b/charts/qtap/templates/service.yaml
@@ -7,15 +7,15 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.tcpPort }}
-      targetPort: tcpService
+      targetPort: tcp-service
       protocol: TCP
-      name: tcpService
+      name: tcp-service
     - port: {{ .Values.service.httpPort }}
-      targetPort: httpService
+      targetPort: http-service
       protocol: TCP
-      name: httpService
+      name: http-service
     - port: {{ .Values.service.httpsPort }}
-      targetPort: httpsService
+      targetPort: https-service
       protocol: TCP
-      name: httpsService
+      name: https-service
   selector: {{- include "qtap.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
Addresses an issue that was shipped in:

- https://github.com/qpoint-io/helm-charts/pull/6
- https://github.com/qpoint-io/helm-charts/pull/7
- https://github.com/qpoint-io/helm-charts/pull/8
- https://github.com/qpoint-io/helm-charts/pull/9

This addresses this type of issue:

```
❯ helm upgrade qtap-gateway qpoint/qtap --namespace qpoint
Error: UPGRADE FAILED: cannot patch "qtap-gateway" with kind Service: Service "qtap-gateway" is invalid: [spec.ports[0].name: Invalid value: "tcpService": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?'), spec.ports[0].targetPort: Invalid value: "tcpService": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-), spec.ports[1].name: Invalid value: "httpService": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?'), spec.ports[1].targetPort: Invalid value: "httpService": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-), spec.ports[2].name: Invalid value: "httpsService": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?'), spec.ports[2].targetPort: Invalid value: "httpsService": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-)] && cannot patch "qtap-gateway" with kind Deployment: Deployment.apps "qtap-gateway" is invalid: [spec.template.spec.containers[0].ports[0].name: Invalid value: "tcpService": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-), spec.template.spec.containers[0].ports[1].name: Invalid value: "httpService": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-), spec.template.spec.containers[0].ports[2].name: Invalid value: "httpsService": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-)]
```