### PR TITLE
Use v in the app versions and for the egress-init-tag

### DIFF
--- a/charts/qtap-operator/Chart.yaml
+++ b/charts/qtap-operator/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: qtap-operator
 description: A Helm chart for a Kubernetes Qtap operator
 type: application
-version: 0.0.1
+version: 0.0.2
 # This is the semantic version of https://github.com/qpoint-io/kubernetes-qtap-operator/releases being deployed
-appVersion: "0.0.1"
+appVersion: "v0.0.2"

--- a/charts/qtap-operator/values.yaml
+++ b/charts/qtap-operator/values.yaml
@@ -46,7 +46,7 @@ controllerManager:
 defaultPodAnnotationsConfigmap:
   annotationsYaml: |-
     qpoint.io/inject-ca: "true"
-    qpoint.io/egress-init-tag: "0.0.5"
+    qpoint.io/egress-init-tag: "v0.0.6"
     qpoint.io/egress-to-domain: "qtap-gateway.qpoint.svc.cluster.local"
 kubernetesClusterDomain: cluster.local
 metricsService:


### PR DESCRIPTION
This uses https://github.com/qpoint-io/kubernetes-qtap-init/releases/tag/v0.0.6 and https://github.com/qpoint-io/kubernetes-qtap-operator/releases/tag/v0.0.2 which pulls in https://github.com/qpoint-io/kubernetes-qtap-operator/pull/9.