### PR TITLE
Update qtap-operator: change the init image and standard egress port mapping

### DIFF
--- a/charts/qtap-operator/Chart.yaml
+++ b/charts/qtap-operator/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: qtap-operator
 description: A Helm chart for a Kubernetes Qtap operator
 type: application
-version: 0.0.3
+version: 0.0.4
 # This is the semantic version of https://github.com/qpoint-io/kubernetes-qtap-operator/releases being deployed
 appVersion: "v0.0.3"

--- a/charts/qtap-operator/values.yaml
+++ b/charts/qtap-operator/values.yaml
@@ -46,8 +46,9 @@ controllerManager:
 defaultPodAnnotationsConfigmap:
   annotationsYaml: |-
     qpoint.io/inject-ca: "true"
-    qpoint.io/egress-init-tag: "v0.0.6"
+    qpoint.io/egress-init-tag: "v0.0.7"
     qpoint.io/egress-to-domain: "qtap-gateway.qpoint.svc.cluster.local"
+    qpoint.io/egress-port-mapping: "10080:80,10443:443"
 kubernetesClusterDomain: cluster.local
 metricsService:
   ports:


### PR DESCRIPTION
This chart updates includes the following:

- Updates to https://github.com/qpoint-io/kubernetes-qtap-init/releases/tag/v0.0.7
- Leverages the `PORT_MAPPING` setting to override the defaults: https://github.com/qpoint-io/kubernetes-qtap-init/blob/c38f58a3ccec7aee05efcb32a88c0e109e4185f6/docker-entrypoint.sh#L27