### PR TITLE
Update qtap to v0.0.6 and change the log level to info

### DIFF
--- a/charts/qtap/Chart.yaml
+++ b/charts/qtap/Chart.yaml
@@ -8,10 +8,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.6
+version: 0.0.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.0.5"
+appVersion: "v0.0.6"

--- a/charts/qtap/values.yaml
+++ b/charts/qtap/values.yaml
@@ -14,7 +14,7 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-args: ["gateway", "--envoy-log-level=error"]
+args: ["gateway", "--envoy-log-level=error", "--log-level=info"]
 
 endpoint: "https://api.qpoint.io"
 


### PR DESCRIPTION
This chart updates includes the following:

- Updates to https://github.com/qpoint-io/qtap/releases/tag/v0.0.6
- Changes the log level to `info`. The default for `qtap` is `error`