### PR TITLE
Correct the format of changed charts to separate word boundaries by spaces

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,8 +21,7 @@ jobs:
           git fetch --depth=2 origin main
           LAST_COMMIT=$(git rev-parse origin/main)
           PREVIOUS_COMMIT=$(git rev-parse origin/main^)
-          CHANGED_CHARTS=$(git diff --name-only $PREVIOUS_COMMIT $LAST_COMMIT charts/ | awk -F/ '{print $2}' | uniq)
-          echo "CHANGED_CHARTS=$CHANGED_CHARTS"
+          CHANGED_CHARTS=$(git diff --name-only $PREVIOUS_COMMIT $LAST_COMMIT charts/ | awk -F/ '{print $2}' | uniq | tr '\n' ' ')
           echo "CHANGED_CHARTS=$CHANGED_CHARTS" >> $GITHUB_ENV
 
       - name: Package and Release Each Changed Chart


### PR DESCRIPTION
There were issues releasing charts together as was done in https://github.com/qpoint-io/helm-charts/pull/16 which lead to lots of reverts to get the `main` branch back into a good state. This addresses the issue.

In this modified script:

- tr '\n' ' ' is used to translate newlines to spaces in the CHANGED_CHARTS variable.
- The for in loop then correctly iterates over each chart.

This way, the for in loop will work as expected with a list of items separated by spaces, which is the typical format expected by such loops in shell scripts.