### PR TITLE
Remove the latest tag

### DIFF
--- a/charts/qtap-operator/Chart.yaml
+++ b/charts/qtap-operator/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: qtap-operator
 description: A Helm chart for a Kubernetes Qtap operator
 type: application
-version: 0.0.8
+version: 0.0.9
 # This is the semantic version of https://github.com/qpoint-io/kubernetes-qtap-operator/releases being deployed
 appVersion: "v0.0.5"

--- a/charts/qtap-operator/values.yaml
+++ b/charts/qtap-operator/values.yaml
@@ -34,7 +34,6 @@ controllerManager:
       endpoint: https://api.qpoint.io
     image:
       repository: us-docker.pkg.dev/qpoint-edge/public/kubernetes-qtap-operator
-      tag: latest
     imagePullPolicy: IfNotPresent
     resources:
       limits:


### PR DESCRIPTION
This issues was introduced in https://github.com/qpoint-io/helm-charts/pull/44. There is no `latest` tag.