### PR TITLE
Update to Qtap Operator v0.0.6 and add new annotations

### DIFF
--- a/charts/qtap-operator/Chart.yaml
+++ b/charts/qtap-operator/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: qtap-operator
 description: A Helm chart for a Kubernetes Qtap operator
 type: application
-version: 0.0.9
+version: 0.0.10
 # This is the semantic version of https://github.com/qpoint-io/kubernetes-qtap-operator/releases being deployed
-appVersion: "v0.0.5"
+appVersion: "v0.0.6"

--- a/charts/qtap-operator/values.yaml
+++ b/charts/qtap-operator/values.yaml
@@ -34,6 +34,7 @@ controllerManager:
       endpoint: https://api.qpoint.io
     image:
       repository: us-docker.pkg.dev/qpoint-edge/public/kubernetes-qtap-operator
+      tag: latest
     imagePullPolicy: IfNotPresent
     resources:
       limits:
@@ -51,9 +52,13 @@ injectPodAnnotationsConfigmap:
     qpoint.io/egress-init-tag: "v0.0.7"
     qpoint.io/qtap-tag: "v0.0.10"
     qpoint.io/egress-port-mapping: "10080:80,10443:443,10000:"
+    qpoint.io/egress-accept-uids: "1010"
+    qpoint.io/egress-accept-gids: "1010"
     qpoint.io/log-level: "info"
     qpoint.io/block-unknown: "false"
     qpoint.io/dns-lookup-family: "V4_ONLY"
+    qpoint.io/qtap-uid: "1010"
+    qpoint.io/qtap-gid: "1010"
 kubernetesClusterDomain: cluster.local
 metricsService:
   ports:
@@ -74,7 +79,6 @@ webhookService:
     protocol: TCP
     targetPort: 9443
   type: ClusterIP
-
 
 # API token
 token: ""


### PR DESCRIPTION
This updates to https://github.com/qpoint-io/kubernetes-qtap-operator/releases/tag/v0.0.6 and adds support for the new annotations to support running the sidecar within pods which have a pod security policy which overrides the UI and GID for the pod. See https://github.com/qpoint-io/kubernetes-qtap-operator/pull/17 for the updates to support the new annotations.