### PR TITLE
Remove the latest tag for the kubernetes-qtap-operator image

### DIFF
--- a/charts/qtap-operator/Chart.yaml
+++ b/charts/qtap-operator/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: qtap-operator
 description: A Helm chart for a Kubernetes Qtap operator
 type: application
-version: 0.0.10
+version: 0.0.11
 # This is the semantic version of https://github.com/qpoint-io/kubernetes-qtap-operator/releases being deployed
 appVersion: "v0.0.6"

--- a/charts/qtap-operator/values.yaml
+++ b/charts/qtap-operator/values.yaml
@@ -34,7 +34,6 @@ controllerManager:
       endpoint: https://api.qpoint.io
     image:
       repository: us-docker.pkg.dev/qpoint-edge/public/kubernetes-qtap-operator
-      tag: latest
     imagePullPolicy: IfNotPresent
     resources:
       limits:


### PR DESCRIPTION
This should have not been introduced in https://github.com/qpoint-io/helm-charts/pull/50/files#diff-2d7c26e563b345467b8655f6e8a6cc4206006ac3c6f9d5e687714f6136ddba8bR37. This reverts the accidental inclusion of the tag.