### PR TITLE
Update Qtap Operator chart to v0.0.12

### DIFF
--- a/charts/qtap-operator/Chart.yaml
+++ b/charts/qtap-operator/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: qtap-operator
 description: A Helm chart for a Kubernetes Qtap operator
 type: application
-version: 0.0.11
+version: 0.0.12
 # This is the semantic version of https://github.com/qpoint-io/kubernetes-qtap-operator/releases being deployed
 appVersion: "v0.0.6"

--- a/charts/qtap-operator/values.yaml
+++ b/charts/qtap-operator/values.yaml
@@ -48,7 +48,7 @@ controllerManager:
 injectPodAnnotationsConfigmap:
   annotationsYaml: |-
     qpoint.io/inject-ca: "true"
-    qpoint.io/egress-init-tag: "v0.0.7"
+    qpoint.io/egress-init-tag: "v0.0.8"
     qpoint.io/qtap-tag: "v0.0.10"
     qpoint.io/egress-port-mapping: "10080:80,10443:443,10000:"
     qpoint.io/egress-accept-uids: "1010"
@@ -69,7 +69,7 @@ metricsService:
 servicePodAnnotationsConfigmap:
   annotationsYaml: |-
     qpoint.io/inject-ca: "true"
-    qpoint.io/egress-init-tag: "v0.0.7"
+    qpoint.io/egress-init-tag: "v0.0.8"
     qpoint.io/egress-to-domain: "qtap-gateway.qpoint.svc.cluster.local"
     qpoint.io/egress-port-mapping: "10080:80,10443:443"
 webhookService:


### PR DESCRIPTION
Bumps init to https://github.com/qpoint-io/kubernetes-qtap-init/releases/tag/v0.0.8 in order to include https://github.com/qpoint-io/kubernetes-qtap-init/pull/11.