### PR TITLE
Update the qtap and qtap-operator charts

### DIFF
--- a/charts/qtap-operator/Chart.yaml
+++ b/charts/qtap-operator/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: qtap-operator
 description: A Helm chart for a Kubernetes Qtap operator
 type: application
-version: 0.0.17
+version: 0.0.18
 # This is the semantic version of https://github.com/qpoint-io/kubernetes-qtap-operator/releases being deployed
-appVersion: "v0.0.9"
+appVersion: "v0.0.10"

--- a/charts/qtap-operator/values.yaml
+++ b/charts/qtap-operator/values.yaml
@@ -49,7 +49,7 @@ injectPodAnnotationsConfigmap:
   annotationsYaml: |-
     qpoint.io/inject-ca: "true"
     qpoint.io/qtap-init-tag: "v0.0.8"
-    qpoint.io/qtap-tag: "v0.0.14"
+    qpoint.io/qtap-tag: "v0.0.15"
     qpoint.io/qtap-init-egress-port-mapping: "10080:80,10443:443"
     qpoint.io/qtap-init-egress-accept-uids: "1010"
     qpoint.io/qtap-init-egress-accept-gids: "1010"
@@ -65,6 +65,7 @@ injectPodAnnotationsConfigmap:
     qpoint.io/qtap-envoy-log-level: "error"
     qpoint.io/qtap-dns-lookup-family: "V4_ONLY"
     qpoint.io/qtap-api-endpoint: "https://api.qpoint.io"
+    qpoint.io/qtap-labels-tags-filter: "app,.*name$"
 kubernetesClusterDomain: cluster.local
 metricsService:
   ports:

--- a/charts/qtap/Chart.yaml
+++ b/charts/qtap/Chart.yaml
@@ -8,10 +8,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.15
+version: 0.0.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.0.14"
+appVersion: "v0.0.15"


### PR DESCRIPTION
This updates the charts to the following versions:

- https://github.com/qpoint-io/qtap/releases/tag/v0.0.15
- https://github.com/qpoint-io/kubernetes-qtap-operator/releases/tag/v0.0.10

The `qtap-operator` chart has been updated to support the new `qtap-labels-tags-filter` annotation with default values.