### PR TITLE
Release Qtap Operator chart v0.0.21 and Qtap chart v0.0.20

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -2,6 +2,17 @@ apiVersion: v1
 entries:
   qtap:
   - apiVersion: v2
+    appVersion: v0.0.19
+    created: "2024-02-16T16:14:43.160601-05:00"
+    description: A Helm chart for running Qtap on Kubernetes
+    digest: 252d0fc96d6e33b7af2c6428e4563005e461abd3e2d9ad6e7b62842f7be998a4
+    icon: data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyBpZD0iTGF5ZXJfMiIgZGF0YS1uYW1lPSJMYXllciAyIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNDMuNjMgMzIuOSI+CiAgPGRlZnM+CiAgICA8c3R5bGU+CiAgICAgIC5jbHMtMSwgLmNscy0yIHsKICAgICAgICBzdHJva2Utd2lkdGg6IDBweDsKICAgICAgfQoKICAgICAgLmNscy0zIHsKICAgICAgICBmaWxsOiBub25lOwogICAgICAgIHN0cm9rZTogIzEwMTQxNzsKICAgICAgICBzdHJva2UtbGluZWNhcDogcm91bmQ7CiAgICAgICAgc3Ryb2tlLW1pdGVybGltaXQ6IDEwOwogICAgICAgIHN0cm9rZS13aWR0aDogMi41NXB4OwogICAgICB9CgogICAgICAuY2xzLTIgewogICAgICAgIGZpbGw6ICMxMDE0MTc7CiAgICAgIH0KICAgIDwvc3R5bGU+CiAgPC9kZWZzPgogIDxnIGlkPSJMYXllcl8yLTIiIGRhdGEtbmFtZT0iTGF5ZXIgMiI+CiAgICA8ZyBpZD0ibG9nby1ibGFjayI+CiAgICAgIDxnPgogICAgICAgIDxsaW5lIGNsYXNzPSJjbHMtMyIgeDE9IjI4LjE3IiB5MT0iMjguMzQiIHgyPSIzMC44NyIgeTI9IjMxLjA0Ii8+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy0yIiBkPSJtMTUuMDEsMEM2LjcyLDAsMCw2LjcyLDAsMTUuMDFzNi43MiwxNS4wMSwxNS4wMSwxNS4wMSwxNS4wMS02LjcyLDE1LjAxLTE1LjAxUzIzLjMsMCwxNS4wMSwwWm04LjMzLDIzLjUxYy0uMjUuMjUtLjU4LjM3LS45LjM3cy0uNjUtLjEyLS45LS4zN2wtMy43Mi0zLjcyYy0uNS0uNS0uNS0xLjMxLDAtMS44MS41LS41LDEuMzEtLjUsMS44MSwwbDMuNzIsMy43MmMuNS41LjUsMS4zMSwwLDEuODFaIi8+CiAgICAgIDwvZz4KICAgICAgPGc+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy0xIiBkPSJtNTUuNDQsMjQuOTNWNi44aDcuNDljMS4zNiwwLDIuNTMuMjYsMy41Mi43OS45OS41MywxLjc1LDEuMjYsMi4yOSwyLjIuNTQuOTQuODEsMi4wNC44MSwzLjI4cy0uMjcsMi4zNC0uODIsMy4yOGMtLjU0Ljk0LTEuMzIsMS42Ni0yLjMzLDIuMTctMS4wMS41MS0yLjIxLjc3LTMuNTkuNzdoLTQuNjJ2LTMuNDVoMy44MWMuNjYsMCwxLjIxLS4xMiwxLjY2LS4zNS40NS0uMjMuNzgtLjU1LDEuMDEtLjk3LjIzLS40Mi4zNC0uOS4zNC0xLjQ2cy0uMTItMS4wNS0uMzQtMS40NmMtLjIzLS40MS0uNTctLjczLTEuMDItLjk1LS40NS0uMjItMS0uMzQtMS42Ni0uMzRoLTIuMTZ2MTQuNmgtNC4zOFoiLz4KICAgICAgICA8cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Im05MC4zLDE1Ljg3YzAsMS45OS0uMzgsMy42OS0xLjE1LDUuMDdzLTEuOCwyLjQ0LTMuMTEsMy4xNmMtMS4zMS43Mi0yLjc3LDEuMDgtNC4zOSwxLjA4cy0zLjEtLjM2LTQuNC0xLjA5Yy0xLjMtLjczLTIuMzQtMS43OC0zLjEtMy4xNy0uNzctMS4zOC0xLjE1LTMuMDctMS4xNS01LjA2cy4zOC0zLjY5LDEuMTUtNS4wN2MuNzYtMS4zOSwxLjgtMi40NCwzLjEtMy4xNiwxLjMtLjcyLDIuNzctMS4wOCw0LjQtMS4wOHMzLjA5LjM2LDQuMzksMS4wOGMxLjMxLjcyLDIuMzQsMS43NywzLjExLDMuMTZzMS4xNSwzLjA4LDEuMTUsNS4wN1ptLTQuNDgsMGMwLTEuMTgtLjE3LTIuMTgtLjUtMi45OS0uMzMtLjgxLS44MS0xLjQzLTEuNDMtMS44NXMtMS4zNy0uNjMtMi4yNC0uNjMtMS42Mi4yMS0yLjI0LjYzLTEuMTEsMS4wNC0xLjQ0LDEuODUtLjUsMS44MS0uNSwyLjk5LjE3LDIuMTguNSwyLjk5LjgxLDEuNDMsMS40NCwxLjg1LDEuMzcuNjMsMi4yNC42MywxLjYyLS4yMSwyLjI0LS42MywxLjEtMS4wNCwxLjQzLTEuODVjLjMzLS44MS41LTEuODEuNS0yLjk5WiIvPgogICAgICAgIDxwYXRoIGNsYXNzPSJjbHMtMSIgZD0ibTk5LjIzLDYuOHYxOC4xM2gtNC4zOFY2LjhoNC4zOFoiLz4KICAgICAgICA8cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Im0xMjEuMzksNi44djE4LjEzaC0zLjcybC03LjIxLTEwLjQ2aC0uMTJ2MTAuNDZoLTQuMzhWNi44aDMuNzdsNy4xMywxMC40NWguMTVWNi44aDQuMzdaIi8+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy0xIiBkPSJtMTI1LjUzLDEwLjM2di0zLjU2aDE1LjMydjMuNTZoLTUuNXYxNC41N2gtNC4zMnYtMTQuNTdoLTUuNTFaIi8+CiAgICAgIDwvZz4KICAgIDwvZz4KICA8L2c+Cjwvc3ZnPg==
+    name: qtap
+    type: application
+    urls:
+    - https://github.com/qpoint-io/helm-charts/releases/download/qtap-0.0.20/qtap-0.0.20.tgz
+    version: 0.0.20
+  - apiVersion: v2
     appVersion: v0.0.18
     created: "2024-02-15T09:50:48.761957-05:00"
     description: A Helm chart for running Qtap on Kubernetes
@@ -213,6 +224,16 @@ entries:
   qtap-operator:
   - apiVersion: v2
     appVersion: v0.0.10
+    created: "2024-02-16T16:14:43.24417-05:00"
+    description: A Helm chart for a Kubernetes Qtap operator
+    digest: 5548d389fb9aa3ad9a60cd34570814a14e17cbdd4497cb5c3196d2625ba18394
+    name: qtap-operator
+    type: application
+    urls:
+    - https://github.com/qpoint-io/helm-charts/releases/download/qtap-operator-0.0.21/qtap-operator-0.0.21.tgz
+    version: 0.0.21
+  - apiVersion: v2
+    appVersion: v0.0.10
     created: "2024-02-15T09:50:48.845281-05:00"
     description: A Helm chart for a Kubernetes Qtap operator
     digest: b6c1ebc500c13e90be98b56ef5fa6167636b2417a6fb45711483a85db4cd8895
@@ -411,4 +432,4 @@ entries:
     urls:
     - https://github.com/qpoint-io/helm-charts/releases/download/qtap-operator-0.0.1/qtap-operator-0.0.1.tgz
     version: 0.0.1
-generated: "2024-02-15T09:50:48.84483-05:00"
+generated: "2024-02-16T16:14:43.243755-05:00"


### PR DESCRIPTION
Releases the following:

- https://github.com/qpoint-io/helm-charts/releases/tag/qtap-0.0.20
- https://github.com/qpoint-io/helm-charts/releases/tag/qtap-operator-0.0.21