### PR TITLE
Update Qtap Operator chart to new app version v0.0.11 and supporting values

### DIFF
--- a/charts/qtap-operator/Chart.yaml
+++ b/charts/qtap-operator/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: qtap-operator
 description: A Helm chart for a Kubernetes Qtap operator
 type: application
-version: 0.0.21
+version: 0.0.22
 # This is the semantic version of https://github.com/qpoint-io/kubernetes-qtap-operator/releases being deployed
-appVersion: "v0.0.10"
+appVersion: "v0.0.11"

--- a/charts/qtap-operator/values.yaml
+++ b/charts/qtap-operator/values.yaml
@@ -49,7 +49,11 @@ injectPodAnnotationsConfigmap:
   annotationsYaml: |-
     qpoint.io/inject-ca: "true"
     qpoint.io/qtap-init-tag: "v0.0.8"
-    qpoint.io/qtap-tag: "v0.0.19"
+    qpoint.io/qtap-init-run-as-user: "0"
+    qpoint.io/qtap-init-run-as-group: "0"
+    qpoint.io/qtap-init-run-as-non-root: "false"
+    qpoint.io/qtap-init-run-as-privileged: "false"
+    qpoint.io/qtap-tag: "v0.0.20"
     qpoint.io/qtap-init-egress-port-mapping: "10080:80,10443:443"
     qpoint.io/qtap-init-egress-accept-uids: "1010"
     qpoint.io/qtap-init-egress-accept-gids: "1010"


### PR DESCRIPTION
This is a chart update for https://github.com/qpoint-io/kubernetes-qtap-operator/releases/tag/v0.0.11. It also updates to https://github.com/qpoint-io/qtap/releases/tag/v0.0.20.