### PR TITLE
Update the NOTES.txt for qpoint-proxy

### DIFF
--- a/charts/qpoint-proxy/Chart.yaml
+++ b/charts/qpoint-proxy/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: 0.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/qpoint-proxy/README.md
+++ b/charts/qpoint-proxy/README.md
@@ -8,7 +8,7 @@ The Qpoint Proxy can operate in two modes:
 
 ```sh
 kubectl --namespace qpoint create secret generic token --from-literal=token="<TOKEN>"
-helm install qpoint-gateway . --namespace qpoint --create-namespace --wait --timeout 20s
+helm install qpoint-proxy . --namespace qpoint --create-namespace --wait --timeout 20s
 ```
 
 2. Standalone mode. For this mode it depends on a config map named `config` with the file contents of a valid YAML configuration file format.

--- a/charts/qpoint-proxy/templates/NOTES.txt
+++ b/charts/qpoint-proxy/templates/NOTES.txt
@@ -1,4 +1,4 @@
-1. Get the application URL by running these commands:
+- Confirm the service endpoints by running these commands:
 
 {{- if eq .Values.service.type "NodePort" }}
 

--- a/charts/qpoint-proxy/templates/NOTES.txt
+++ b/charts/qpoint-proxy/templates/NOTES.txt
@@ -1,16 +1,63 @@
 1. Get the application URL by running these commands:
-{{- if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "qpoint.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "qpoint.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "qpoint.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "qpoint.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+
+{{- if eq .Values.service.type "NodePort" }}
+
+  echo "Waiting for the NodePort service to be available..."
+  wait_for_nodeport() {
+    local ready=true
+    {{- range .Values.service.ports }}
+    local node_port=$(kubectl get --namespace {{ $.Release.Namespace }} -o jsonpath="{.spec.ports[?(@.name=='{{ .name }}')].nodePort}" services {{ include "qpoint.fullname" $ }})
+    if [ -z "$node_port" ]; then
+      echo "waiting for service to be available..."
+      ready=false
+    else
+      for node_ip in $(kubectl get nodes --namespace {{ $.Release.Namespace }} -o jsonpath="{.items[*].status.addresses[?(@.type=='InternalIP')].address}"); do
+        echo "$node_ip:$node_port for {{ .name }} ({{ .description }})"
+      done
+    fi
+    {{- end }}
+    if [ "$ready" = true ]; then
+      return 0
+    else
+      return 1
+    fi
+  }
+  until wait_for_nodeport; do sleep 1; done
+
+{{- else if eq .Values.service.type "LoadBalancer" }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+
+  echo "Waiting for the LoadBalancer IP to be available..."
+  wait_for_loadbalancer() {
+    local service_ip=$(kubectl get services --namespace {{ $.Release.Namespace }} {{ include "qpoint.fullname" $ }} -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
+    if [ -z "$service_ip" ]; then
+      echo "waiting for service to be available..."
+      return 1
+    else
+      {{- range .Values.service.ports }}
+      echo "$service_ip:{{ .port }} for {{ .name }} ({{ .description }})"
+      {{- end }}
+      return 0
+    fi
+  }
+  until wait_for_loadbalancer; do sleep 1; done
+
+{{- else if eq .Values.service.type "ClusterIP" }}
+
+  echo "Waiting for the ClusterIP service to be available..."
+  wait_for_clusterip() {
+    local cluster_ip=$(kubectl get services --namespace {{ $.Release.Namespace }} {{ include "qpoint.fullname" $ }} -o jsonpath="{.spec.clusterIP}")
+    if [ -z "$cluster_ip" ]; then
+      echo "waiting for service to be available..."
+      return 1
+    else
+      {{- range .Values.service.ports }}
+      echo "$cluster_ip:{{ .port }} for {{ .name }} ({{ .description }})"
+      {{- end }}
+      echo "DNS: {{ include "qpoint.fullname" $ }}.{{ $.Release.Namespace }}.svc.cluster.local"
+      return 0
+    fi
+  }
+  until wait_for_clusterip; do sleep 1; done
+
 {{- end }}

--- a/charts/qpoint-proxy/values.yaml
+++ b/charts/qpoint-proxy/values.yaml
@@ -50,24 +50,28 @@ middlewareTCPForwardPorts: "18080:80,18443:443"
 transparentTCPForwardPorts: "10080:80,10443:443"
 
 service:
-  type: ClusterIP
+  type: LoadBalancer
   ports:
     - port: 10080
       containerPort: 10080
       protocol: TCP
       name: e-http-tr
+      description: "Egress HTTP, transparent proxy"
     - port: 10443
       containerPort: 10443
       protocol: TCP
       name: e-https-tr
+      description: "Egress HTTPS, transparent proxy"
     - port: 18080
       containerPort: 18080
       protocol: TCP
       name: e-http-mi
+      description: "Egress HTTP, middleware proxy"
     - port: 18443
       containerPort: 18443
       protocol: TCP
       name: e-https-mi
+      description: "Egress HTTPS, middleware proxy"
 
 status:
   addr: 0.0.0.0


### PR DESCRIPTION
The NOTES.txt have been updates for service types `ClusterIP`, `LoadBalancer` and `NodePort`. Below are examples of how they work:

### ClusterIP

```
helm install qpoint-proxy . --set registrationToken="<SNIP>" --namespace qpoint --create-namespace
NAME: qpoint-proxy
LAST DEPLOYED: Tue Jun 18 11:30:53 2024
NAMESPACE: qpoint
STATUS: deployed
REVISION: 1
NOTES:
1. Get the application URL by running these commands:

  echo "Waiting for the ClusterIP service to be available..."
  wait_for_clusterip() {
    local cluster_ip=$(kubectl get services --namespace qpoint qpoint-proxy -o jsonpath="{.spec.clusterIP}")
    if [ -z "$cluster_ip" ]; then
      echo "waiting for service to be available..."
      return 1
    else
      echo "$cluster_ip:10080 for e-http-tr (Egress HTTP, transparent proxy)"
      echo "$cluster_ip:10443 for e-https-tr (Egress HTTPS, transparent proxy)"
      echo "$cluster_ip:18080 for e-http-mi (Egress HTTP, middleware proxy)"
      echo "$cluster_ip:18443 for e-https-mi (Egress HTTPS, middleware proxy)"
      echo "DNS: qpoint-proxy.qpoint.svc.cluster.local"
      return 0
    fi
  }
  until wait_for_clusterip; do sleep 1; done
```
```
echo "Waiting for the ClusterIP service to be available..."
  wait_for_clusterip() {
    local cluster_ip=$(kubectl get services --namespace qpoint qpoint-proxy -o jsonpath="{.spec.clusterIP}")
    if [ -z "$cluster_ip" ]; then
      echo "waiting for service to be available..."
      return 1
    else
      echo "$cluster_ip:10080 for e-http-tr (Egress HTTP, transparent proxy)"
      echo "$cluster_ip:10443 for e-https-tr (Egress HTTPS, transparent proxy)"
      echo "$cluster_ip:18080 for e-http-mi (Egress HTTP, middleware proxy)"
      echo "$cluster_ip:18443 for e-https-mi (Egress HTTPS, middleware proxy)"
      echo "DNS: qpoint-proxy.qpoint.svc.cluster.local"
      return 0
    fi
  }
  until wait_for_clusterip; do sleep 1; done
Waiting for the ClusterIP service to be available...
34.118.225.131:10080 for e-http-tr (Egress HTTP, transparent proxy)
34.118.225.131:10443 for e-https-tr (Egress HTTPS, transparent proxy)
34.118.225.131:18080 for e-http-mi (Egress HTTP, middleware proxy)
34.118.225.131:18443 for e-https-mi (Egress HTTPS, middleware proxy)
DNS: qpoint-proxy.qpoint.svc.cluster.local
```

### LoadBalancer

```
helm install qpoint-proxy . --set registrationToken="<SNIP>" --namespace qpoint --create-namespace
W0618 11:31:59.737691   55511 warnings.go:70] autopilot-default-resources-mutator:Autopilot updated Deployment qpoint/qpoint-proxy: defaulted unspecified 'cpu' resource for containers [qpoint-proxy] (see http://g.co/gke/autopilot-defaults).
NAME: qpoint-proxy
LAST DEPLOYED: Tue Jun 18 11:31:58 2024
NAMESPACE: qpoint
STATUS: deployed
REVISION: 1
NOTES:
1. Get the application URL by running these commands:
  NOTE: It may take a few minutes for the LoadBalancer IP to be available.

  echo "Waiting for the LoadBalancer IP to be available..."
  wait_for_loadbalancer() {
    local service_ip=$(kubectl get services --namespace qpoint qpoint-proxy -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
    if [ -z "$service_ip" ]; then
      echo "waiting for service to be available..."
      return 1
    else
      echo "$service_ip:10080 for e-http-tr (Egress HTTP, transparent proxy)"
      echo "$service_ip:10443 for e-https-tr (Egress HTTPS, transparent proxy)"
      echo "$service_ip:18080 for e-http-mi (Egress HTTP, middleware proxy)"
      echo "$service_ip:18443 for e-https-mi (Egress HTTPS, middleware proxy)"
      return 0
    fi
  }
  until wait_for_loadbalancer; do sleep 1; done
```
```
echo "Waiting for the LoadBalancer IP to be available..."
  wait_for_loadbalancer() {
    local service_ip=$(kubectl get services --namespace qpoint qpoint-proxy -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
    if [ -z "$service_ip" ]; then
      echo "waiting for service to be available..."
      return 1
    else
      echo "$service_ip:10080 for e-http-tr (Egress HTTP, transparent proxy)"
      echo "$service_ip:10443 for e-https-tr (Egress HTTPS, transparent proxy)"
      echo "$service_ip:18080 for e-http-mi (Egress HTTP, middleware proxy)"
      echo "$service_ip:18443 for e-https-mi (Egress HTTPS, middleware proxy)"
      return 0
    fi
  }
  until wait_for_loadbalancer; do sleep 1; done
Waiting for the LoadBalancer IP to be available...
waiting for service to be available...
waiting for service to be available...
waiting for service to be available...
waiting for service to be available...
waiting for service to be available...
waiting for service to be available...
waiting for service to be available...
waiting for service to be available...
waiting for service to be available...
waiting for service to be available...
waiting for service to be available...
waiting for service to be available...
waiting for service to be available...
waiting for service to be available...
waiting for service to be available...
waiting for service to be available...
waiting for service to be available...
waiting for service to be available...
waiting for service to be available...
waiting for service to be available...
waiting for service to be available...
waiting for service to be available...
34.139.43.67:10080 for e-http-tr (Egress HTTP, transparent proxy)
34.139.43.67:10443 for e-https-tr (Egress HTTPS, transparent proxy)
34.139.43.67:18080 for e-http-mi (Egress HTTP, middleware proxy)
34.139.43.67:18443 for e-https-mi (Egress HTTPS, middleware proxy)
```

### NodePort

```
helm install qpoint-proxy . --set registrationToken="<SNIP>" --namespace qpoint --create-namespace
W0618 11:22:18.643871   49314 warnings.go:70] autopilot-default-resources-mutator:Autopilot updated Deployment qpoint/qpoint-proxy: defaulted unspecified 'cpu' resource for containers [qpoint-proxy] (see http://g.co/gke/autopilot-defaults).
NAME: qpoint-proxy
LAST DEPLOYED: Tue Jun 18 11:22:17 2024
NAMESPACE: qpoint
STATUS: deployed
REVISION: 1
NOTES:
1. Get the application URL by running these commands:

  echo "Waiting for the NodePort service to be available..."
  wait_for_nodeport() {
    local ready=true
    local node_port=$(kubectl get --namespace qpoint -o jsonpath="{.spec.ports[?(@.name=='e-http-tr')].nodePort}" services qpoint-proxy)
    if [ -z "$node_port" ]; then
      echo "waiting for service to be available..."
      ready=false
    else
      for node_ip in $(kubectl get nodes --namespace qpoint -o jsonpath="{.items[*].status.addresses[?(@.type=='InternalIP')].address}"); do
        echo "$node_ip:$node_port for e-http-tr (Egress HTTP, transparent proxy)"
      done
    fi
    local node_port=$(kubectl get --namespace qpoint -o jsonpath="{.spec.ports[?(@.name=='e-https-tr')].nodePort}" services qpoint-proxy)
    if [ -z "$node_port" ]; then
      echo "waiting for service to be available..."
      ready=false
    else
      for node_ip in $(kubectl get nodes --namespace qpoint -o jsonpath="{.items[*].status.addresses[?(@.type=='InternalIP')].address}"); do
        echo "$node_ip:$node_port for e-https-tr (Egress HTTPS, transparent proxy)"
      done
    fi
    local node_port=$(kubectl get --namespace qpoint -o jsonpath="{.spec.ports[?(@.name=='e-http-mi')].nodePort}" services qpoint-proxy)
    if [ -z "$node_port" ]; then
      echo "waiting for service to be available..."
      ready=false
    else
      for node_ip in $(kubectl get nodes --namespace qpoint -o jsonpath="{.items[*].status.addresses[?(@.type=='InternalIP')].address}"); do
        echo "$node_ip:$node_port for e-http-mi (Egress HTTP, middleware proxy)"
      done
    fi
    local node_port=$(kubectl get --namespace qpoint -o jsonpath="{.spec.ports[?(@.name=='e-https-mi')].nodePort}" services qpoint-proxy)
    if [ -z "$node_port" ]; then
      echo "waiting for service to be available..."
      ready=false
    else
      for node_ip in $(kubectl get nodes --namespace qpoint -o jsonpath="{.items[*].status.addresses[?(@.type=='InternalIP')].address}"); do
        echo "$node_ip:$node_port for e-https-mi (Egress HTTPS, middleware proxy)"
      done
    fi
    if [ "$ready" = true ]; then
      return 0
    else
      return 1
    fi
  }
  until wait_for_nodeport; do sleep 1; done
```
```
echo "Waiting for the NodePort service to be available..."
  wait_for_nodeport() {
    local ready=true
    local node_port=$(kubectl get --namespace qpoint -o jsonpath="{.spec.ports[?(@.name=='e-http-tr')].nodePort}" services qpoint-proxy)
    if [ -z "$node_port" ]; then
      echo "waiting for service to be available..."
      ready=false
    else
      for node_ip in $(kubectl get nodes --namespace qpoint -o jsonpath="{.items[*].status.addresses[?(@.type=='InternalIP')].address}"); do
        echo "$node_ip:$node_port for e-http-tr (Egress HTTP, transparent proxy)"
      done
    fi
    local node_port=$(kubectl get --namespace qpoint -o jsonpath="{.spec.ports[?(@.name=='e-https-tr')].nodePort}" services qpoint-proxy)
    if [ -z "$node_port" ]; then
      echo "waiting for service to be available..."
      ready=false
    else
      for node_ip in $(kubectl get nodes --namespace qpoint -o jsonpath="{.items[*].status.addresses[?(@.type=='InternalIP')].address}"); do
        echo "$node_ip:$node_port for e-https-tr (Egress HTTPS, transparent proxy)"
      done
    fi
    local node_port=$(kubectl get --namespace qpoint -o jsonpath="{.spec.ports[?(@.name=='e-http-mi')].nodePort}" services qpoint-proxy)
    if [ -z "$node_port" ]; then
      echo "waiting for service to be available..."
      ready=false
    else
      for node_ip in $(kubectl get nodes --namespace qpoint -o jsonpath="{.items[*].status.addresses[?(@.type=='InternalIP')].address}"); do
        echo "$node_ip:$node_port for e-http-mi (Egress HTTP, middleware proxy)"
      done
    fi
    local node_port=$(kubectl get --namespace qpoint -o jsonpath="{.spec.ports[?(@.name=='e-https-mi')].nodePort}" services qpoint-proxy)
    if [ -z "$node_port" ]; then
      echo "waiting for service to be available..."
      ready=false
    else
      for node_ip in $(kubectl get nodes --namespace qpoint -o jsonpath="{.items[*].status.addresses[?(@.type=='InternalIP')].address}"); do
        echo "$node_ip:$node_port for e-https-mi (Egress HTTPS, middleware proxy)"
      done
    fi
    if [ "$ready" = true ]; then
      return 0
    else
      return 1
    fi
  }
  until wait_for_nodeport; do sleep 1; done
Waiting for the NodePort service to be available...
10.142.0.4:31694 for e-http-tr (Egress HTTP, transparent proxy)
10.142.0.4:30437 for e-https-tr (Egress HTTPS, transparent proxy)
10.142.0.4:31235 for e-http-mi (Egress HTTP, middleware proxy)
10.142.0.4:32706 for e-https-mi (Egress HTTPS, middleware proxy)
```