### PR TITLE
Revert back to ClusterIP as default

### DIFF
--- a/charts/qpoint-proxy/Chart.yaml
+++ b/charts/qpoint-proxy/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: 0.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/qpoint-proxy/values.yaml
+++ b/charts/qpoint-proxy/values.yaml
@@ -50,7 +50,7 @@ middlewareTCPForwardPorts: "18080:80,18443:443"
 transparentTCPForwardPorts: "10080:80,10443:443"
 
 service:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - port: 10080
       containerPort: 10080


### PR DESCRIPTION
#91 inadvertently made the default service type `LoadBalancer`. This reverts back to `ClusterIP`.