### PR TITLE
Update the NOTES.txt for qpoint-connect.

### DIFF
--- a/charts/qpoint-connect/Chart.yaml
+++ b/charts/qpoint-connect/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: 0.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/qpoint-connect/templates/NOTES.txt
+++ b/charts/qpoint-connect/templates/NOTES.txt
@@ -1,16 +1,63 @@
-1. Get the application URL by running these commands:
-{{- if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "qpoint.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "qpoint.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "qpoint.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "qpoint.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+- Confirm the service endpoints by running these commands:
+
+{{- if eq .Values.service.type "NodePort" }}
+
+  echo "Waiting for the NodePort service to be available..."
+  wait_for_nodeport() {
+    local ready=true
+    {{- range .Values.service.ports }}
+    local node_port=$(kubectl get --namespace {{ $.Release.Namespace }} -o jsonpath="{.spec.ports[?(@.name=='{{ .name }}')].nodePort}" services {{ include "qpoint.fullname" $ }})
+    if [ -z "$node_port" ]; then
+      echo "waiting for service to be available..."
+      ready=false
+    else
+      for node_ip in $(kubectl get nodes --namespace {{ $.Release.Namespace }} -o jsonpath="{.items[*].status.addresses[?(@.type=='InternalIP')].address}"); do
+        echo "$node_ip:$node_port for {{ .name }} ({{ .description }})"
+      done
+    fi
+    {{- end }}
+    if [ "$ready" = true ]; then
+      return 0
+    else
+      return 1
+    fi
+  }
+  until wait_for_nodeport; do sleep 1; done
+
+{{- else if eq .Values.service.type "LoadBalancer" }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+
+  echo "Waiting for the LoadBalancer IP to be available..."
+  wait_for_loadbalancer() {
+    local service_ip=$(kubectl get services --namespace {{ $.Release.Namespace }} {{ include "qpoint.fullname" $ }} -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
+    if [ -z "$service_ip" ]; then
+      echo "waiting for service to be available..."
+      return 1
+    else
+      {{- range .Values.service.ports }}
+      echo "$service_ip:{{ .port }} for {{ .name }} ({{ .description }})"
+      {{- end }}
+      return 0
+    fi
+  }
+  until wait_for_loadbalancer; do sleep 1; done
+
+{{- else if eq .Values.service.type "ClusterIP" }}
+
+  echo "Waiting for the ClusterIP service to be available..."
+  wait_for_clusterip() {
+    local cluster_ip=$(kubectl get services --namespace {{ $.Release.Namespace }} {{ include "qpoint.fullname" $ }} -o jsonpath="{.spec.clusterIP}")
+    if [ -z "$cluster_ip" ]; then
+      echo "waiting for service to be available..."
+      return 1
+    else
+      {{- range .Values.service.ports }}
+      echo "$cluster_ip:{{ .port }} for {{ .name }} ({{ .description }})"
+      {{- end }}
+      echo "DNS: {{ include "qpoint.fullname" $ }}.{{ $.Release.Namespace }}.svc.cluster.local"
+      return 0
+    fi
+  }
+  until wait_for_clusterip; do sleep 1; done
+
 {{- end }}

--- a/charts/qpoint-connect/values.yaml
+++ b/charts/qpoint-connect/values.yaml
@@ -44,7 +44,7 @@ securityContext:
   # runAsUser: 1000
 
 defaultTCPListenAddress: "0.0.0.0"
-connectTCPForwardPorts: "16080:80,16443:443"
+connectTCPForwardPorts: "16443:443"
 connectUpstream: "localhost:10443"
 
 # Default to an empty username and password
@@ -54,14 +54,11 @@ connectPassword: "default"
 service:
   type: ClusterIP
   ports:
-    - port: 16080
-      containerPort: 16080
-      protocol: TCP
-      name: e-http
     - port: 16443
       containerPort: 16443
       protocol: TCP
       name: e-https
+      description: "Egress HTTPS, CONNECT proxy"
 
 status:
   addr: 0.0.0.0


### PR DESCRIPTION
Similar to https://github.com/qpoint-io/helm-charts/pull/91 but for the `qpoint-connect` chart.

### ClusterIP

```
helm install qpoint-connect . --set connectUpstream="qpoint-proxy.qpoint.svc.cluster.local:10443" --namespace qpoint
NAME: qpoint-connect
LAST DEPLOYED: Tue Jun 18 13:01:02 2024
NAMESPACE: qpoint
STATUS: deployed
REVISION: 1
NOTES:
- Confirm the service endpoints by running these commands:

  echo "Waiting for the ClusterIP service to be available..."
  wait_for_clusterip() {
    local cluster_ip=$(kubectl get services --namespace qpoint qpoint-connect -o jsonpath="{.spec.clusterIP}")
    if [ -z "$cluster_ip" ]; then
      echo "waiting for service to be available..."
      return 1
    else
      echo "$cluster_ip:16443 for e-https (Egress HTTPS, CONNECT proxy)"
      echo "DNS: qpoint-connect.qpoint.svc.cluster.local"
      return 0
    fi
  }
  until wait_for_clusterip; do sleep 1; done
```
```
echo "Waiting for the ClusterIP service to be available..."
  wait_for_clusterip() {
    local cluster_ip=$(kubectl get services --namespace qpoint qpoint-connect -o jsonpath="{.spec.clusterIP}")
    if [ -z "$cluster_ip" ]; then
      echo "waiting for service to be available..."
      return 1
    else
      echo "$cluster_ip:16443 for e-https (Egress HTTPS, CONNECT proxy)"
      echo "DNS: qpoint-connect.qpoint.svc.cluster.local"
      return 0
    fi
  }
  until wait_for_clusterip; do sleep 1; done
Waiting for the ClusterIP service to be available...
34.118.231.10:16443 for e-https (Egress HTTPS, CONNECT proxy)
DNS: qpoint-connect.qpoint.svc.cluster.local
```