### PR TITLE
Fix port mixup between transparent and middleware enabled ports

### DIFF
--- a/charts/qpoint-proxy/Chart.yaml
+++ b/charts/qpoint-proxy/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.6
+version: 0.0.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/qpoint-proxy/values.yaml
+++ b/charts/qpoint-proxy/values.yaml
@@ -46,8 +46,8 @@ securityContext:
   # runAsUser: 1000
 
 defaultTCPListenAddress: "0.0.0.0"
-middlewareTCPForwardPorts: "18080:80,18443:443"
-transparentTCPForwardPorts: "10080:80,10443:443"
+middlewareTCPForwardPorts: "10080:80,10443:443"
+transparentTCPForwardPorts: "18080:80,18443:443"
 
 service:
   type: ClusterIP
@@ -55,23 +55,23 @@ service:
     - port: 10080
       containerPort: 10080
       protocol: TCP
-      name: e-http-tr
-      description: "Egress HTTP, transparent proxy"
+      name: e-http-mi
+      description: "Egress HTTP, middleware proxy"
     - port: 10443
       containerPort: 10443
       protocol: TCP
-      name: e-https-tr
-      description: "Egress HTTPS, transparent proxy"
+      name: e-https-mi
+      description: "Egress HTTPS, middleware proxy"
     - port: 18080
       containerPort: 18080
       protocol: TCP
-      name: e-http-mi
-      description: "Egress HTTP, middleware proxy"
+      name: e-http-tr
+      description: "Egress HTTP, transparent proxy"
     - port: 18443
       containerPort: 18443
       protocol: TCP
-      name: e-https-mi
-      description: "Egress HTTPS, middleware proxy"
+      name: e-https-tr
+      description: "Egress HTTPS, transparent proxy"
 
 status:
   addr: 0.0.0.0


### PR DESCRIPTION
This issue has existed since the creation of the chart and the diff can be seen under https://github.com/qpoint-io/helm-charts/commit/176cadebe60ab78691cfde4df1b4c11961d8c735. The original pull request had mixed up the ports and this led to confusion.

The middleware ports are `10080` and `10443` and the transparent `10080` and `10443`.