### PR TITLE
Move command line args to configurable values

### DIFF
--- a/charts/qpoint-connect/Chart.yaml
+++ b/charts/qpoint-connect/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.5
+version: 0.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/qpoint-connect/templates/deployment.yaml
+++ b/charts/qpoint-connect/templates/deployment.yaml
@@ -51,6 +51,16 @@ spec:
               value: "{{ .Values.connectUsername }}"
             - name: CONNECT_PASSWORD
               value: "{{ .Values.connectPassword }}"
+            - name: ACCESS_LOG
+              value: "{{ .Values.accessLog }}"
+            - name: LOG_LEVEL
+              value: "{{ .Values.logLevel }}"
+            - name: LOG_ENCODING
+              value: "{{ .Values.logEncoding }}"
+            - name: ENVOY_LOG_LEVEL
+              value: "{{ .Values.envoyLogLevel }}"
+            - name: DNS_LOOKUP_FAMILY
+              value: "{{ .Values.dnsLookupFamily }}"
           ports:
         {{- range .Values.service.ports }}
             - name: {{ .name }}

--- a/charts/qpoint-connect/values.yaml
+++ b/charts/qpoint-connect/values.yaml
@@ -14,7 +14,7 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-args: ["connect", "--envoy-log-level=error", "--log-level=info", "--dns-lookup-family=V4_ONLY"]
+args: ["connect"]
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -50,6 +50,21 @@ connectUpstream: "localhost:10443"
 # Default to an empty username and password
 connectUsername: "default"
 connectPassword: "default"
+
+# To enable access logs change to true
+accessLog: false
+
+# One of debug, info, warn, error, dpanic, panic, fatal
+logLevel: "info"
+
+# One of console, json
+logEncoding: "json"
+
+# One of trace, debug, info, warn, error, critical, off
+envoyLogLevel: "error"
+
+# One of AUTO, V4_ONLY, V6_ONLY, V4_PREFERRED, ALL
+dnsLookupFamily: "V4_ONLY"
 
 service:
   type: ClusterIP

--- a/charts/qpoint-proxy/Chart.yaml
+++ b/charts/qpoint-proxy/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.7
+version: 0.0.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/qpoint-proxy/templates/deployment.yaml
+++ b/charts/qpoint-proxy/templates/deployment.yaml
@@ -60,6 +60,16 @@ spec:
               value: "{{ .Values.middlewareTCPForwardPorts }}"
             - name: TRANSPARENT_TCP_FORWARD_PORTS
               value: "{{ .Values.transparentTCPForwardPorts }}"
+            - name: ACCESS_LOG
+              value: "{{ .Values.accessLog }}"
+            - name: LOG_LEVEL
+              value: "{{ .Values.logLevel }}"
+            - name: LOG_ENCODING
+              value: "{{ .Values.logEncoding }}"
+            - name: ENVOY_LOG_LEVEL
+              value: "{{ .Values.envoyLogLevel }}"
+            - name: DNS_LOOKUP_FAMILY
+              value: "{{ .Values.dnsLookupFamily }}"
           ports:
         {{- range .Values.service.ports }}
             - name: {{ .name }}

--- a/charts/qpoint-proxy/values.yaml
+++ b/charts/qpoint-proxy/values.yaml
@@ -14,7 +14,7 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-args: ["proxy", "--envoy-log-level=error", "--log-level=info", "--dns-lookup-family=V4_ONLY"]
+args: ["proxy"]
 
 registrationEndpoint: "https://api.qpoint.io"
 
@@ -48,6 +48,21 @@ securityContext:
 defaultTCPListenAddress: "0.0.0.0"
 middlewareTCPForwardPorts: "10080:80,10443:443"
 transparentTCPForwardPorts: "18080:80,18443:443"
+
+# To enable access logs change to true
+accessLog: false
+
+# One of debug, info, warn, error, dpanic, panic, fatal
+logLevel: "info"
+
+# One of console, json
+logEncoding: "json"
+
+# One of trace, debug, info, warn, error, critical, off
+envoyLogLevel: "error"
+
+# One of AUTO, V4_ONLY, V6_ONLY, V4_PREFERRED, ALL
+dnsLookupFamily: "V4_ONLY"
 
 service:
   type: ClusterIP


### PR DESCRIPTION
This pull request moves some command line arguments into values so that they can be set individually. This includes the ability to enable access logs, set the log levels, change the log encoding and modify the DNS lookup family.