### PR TITLE
Update Qpoint Tap to Qpoint v0.2.5 and introduce resource limits

### DIFF
--- a/charts/qpoint-tap/Chart.yaml
+++ b/charts/qpoint-tap/Chart.yaml
@@ -8,10 +8,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: 0.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.1.10"
+appVersion: "v0.2.5"

--- a/charts/qpoint-tap/values.yaml
+++ b/charts/qpoint-tap/values.yaml
@@ -59,18 +59,15 @@ middlewareEgress:
   addr: 127.0.0.1
   port: 11001
 
+# The following resources are used for the tap pod. They need to be adjusted to your needs and based
+# on the resources available on your cluster.
 resources:
-  {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+  requests:
+    cpu: 100m
+    memory: 128Mi
 
 # Additional volumes on the output Deployment definition.
 volumes:


### PR DESCRIPTION
This updates to Qpoint `v0.2.5` and introduces default resource limits.

The default limits are the following:
```
limits:
  cpu: 1000m
  memory: 1Gi
requests:
  cpu: 100m
  memory: 128Mi
```

The `requests` for `cpu` and `memory` should be adequate for most deployments but depends on the complexity of the middleware running and the number of active processes on the cluster. This needs to be updated if the usage far exceeds these values. Similarly, the `limit` is put in place to protect the system from memory and CPU exhaustion. Operators need to ensure this is adequate for their needs and can be adjusted during deployment should high limits be required.