### PR TITLE
Update Qtap to v0.2.7 and support extra environment variables

### DIFF
--- a/charts/qpoint-tap/Chart.yaml
+++ b/charts/qpoint-tap/Chart.yaml
@@ -8,10 +8,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.5
+version: 0.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.2.6"
+appVersion: "v0.2.7"

--- a/charts/qpoint-tap/templates/daemonset.yaml
+++ b/charts/qpoint-tap/templates/daemonset.yaml
@@ -59,6 +59,12 @@ spec:
               value: "{{ .Values.logEncoding }}"
             - name: TINI_SUBREAPER
               value: "1"
+            {{- if .Values.extraEnv }}
+            {{- range .Values.extraEnv }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+            {{- end }}
           ports:
             - name: status
               containerPort: {{ .Values.status.port }}

--- a/charts/qpoint-tap/values.yaml
+++ b/charts/qpoint-tap/values.yaml
@@ -111,3 +111,8 @@ config: ""
 #     jwt_hmac_key: "qwertyuiopasdfghjklzxcvbnm123456"
 #     default_domain_action: ALLOW
 #     endpoints: []
+
+# Additional environment variables for the DaemonSet
+extraEnv:
+  - name: BPF_TRACE
+    value: "mod:openssl,mod:protocol,exe.contains:curl"

--- a/charts/qpoint-tap/values.yaml
+++ b/charts/qpoint-tap/values.yaml
@@ -113,6 +113,6 @@ config: ""
 #     endpoints: []
 
 # Additional environment variables for the DaemonSet
-extraEnv:
-  - name: BPF_TRACE
-    value: "mod:openssl,mod:protocol,exe.contains:curl"
+# extraEnv:
+#   - name: BPF_TRACE
+#     value: "mod:openssl,mod:protocol,exe.contains:curl"


### PR DESCRIPTION
This updates to https://github.com/qpoint-io/qpoint/releases/tag/v0.2.7 and adds support for adding extra environment variables to the daemonset.