### PR TITLE
Support putting the registration token in a secret which the chart will use

### DIFF
--- a/charts/qpoint-tap/Chart.yaml
+++ b/charts/qpoint-tap/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.8
+version: 0.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/qpoint-tap/templates/daemonset.yaml
+++ b/charts/qpoint-tap/templates/daemonset.yaml
@@ -40,7 +40,13 @@ spec:
           env:
             - name: REGISTRATION_ENDPOINT
               value: "{{ .Values.registrationEndpoint }}"
-            {{- if .Values.registrationToken }}
+            {{- if .Values.registrationTokenSecretRefName }}
+            - name: REGISTRATION_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.registrationTokenSecretRefName }}
+                  key: token
+            {{- else if .Values.registrationToken }}
             - name: REGISTRATION_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/charts/qpoint-tap/values.yaml
+++ b/charts/qpoint-tap/values.yaml
@@ -96,6 +96,8 @@ affinity: {}
 
 # API token
 registrationToken: ""
+# OR
+# registrationTokenSecretRefName: ""
 
 config: ""
 # config: |


### PR DESCRIPTION
This introduces a `registrationTokenSecretRefName` which will reference the name of an existing secret within the same namespace as the installation. This secret can be used instead of the chart creating a secret that it will use.