### PR TITLE
Support extra environment variables from secrets and move to Qpoint v0.4.7

### DIFF
--- a/charts/qpoint-tap/Chart.yaml
+++ b/charts/qpoint-tap/Chart.yaml
@@ -8,10 +8,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.9
+version: 0.0.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.4.5"
+appVersion: "v0.4.7"

--- a/charts/qpoint-tap/templates/daemonset.yaml
+++ b/charts/qpoint-tap/templates/daemonset.yaml
@@ -68,7 +68,12 @@ spec:
             {{- if .Values.extraEnv }}
             {{- range .Values.extraEnv }}
             - name: {{ .name }}
+              {{- if .value }}
               value: {{ .value | quote }}
+              {{- else if .valueFrom }}
+              valueFrom:
+                {{- toYaml .valueFrom | nindent 16 }}
+              {{- end }}
             {{- end }}
             {{- end }}
           ports:

--- a/charts/qpoint-tap/values.yaml
+++ b/charts/qpoint-tap/values.yaml
@@ -116,10 +116,10 @@ config: ""
 # extraEnv:
 #   - name: BPF_TRACE
 #     value: "mod:openssl,mod:protocol,exe.contains:curl"
-# - name: SOME_ENV_VAR
-#   valueFrom:
-#     secretKeyRef:
+#   - name: SOME_ENV_VAR
+#     valueFrom:
+#       secretKeyRef:
 #       name: some-secret
 #       key: some-key
-  # - name: TLS_PROBES
-  #   value: "openssl"
+#   - name: TLS_PROBES
+#     value: "openssl"

--- a/charts/qpoint-tap/values.yaml
+++ b/charts/qpoint-tap/values.yaml
@@ -116,3 +116,10 @@ config: ""
 # extraEnv:
 #   - name: BPF_TRACE
 #     value: "mod:openssl,mod:protocol,exe.contains:curl"
+# - name: SOME_ENV_VAR
+#   valueFrom:
+#     secretKeyRef:
+#       name: some-secret
+#       key: some-key
+  # - name: TLS_PROBES
+  #   value: "openssl"


### PR DESCRIPTION
This allows for environment variables to be set from secrets. For example, assume a secret is created with the following:

```
kubectl create secret generic some-secret --from-literal=some-key='blah' -n qpoint
```

This secret named `some-secret` can be referenced to set an environment variable with the following:

```
extraEnv:
  - name: BPF_TRACE
    value: "mod:openssl,mod:protocol,exe.contains:curl"
  - name: SOME_ENV_VAR
    valueFrom:
      secretKeyRef:
      name: some-secret
      key: some-key
  - name: TLS_PROBES
    value: "openssl"
```