### PR TITLE
adds containerd socket hostpath mount

### DIFF
--- a/charts/qpoint-tap/templates/daemonset.yaml
+++ b/charts/qpoint-tap/templates/daemonset.yaml
@@ -116,6 +116,10 @@ spec:
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- if .Values.integrations.containerd.enabled }}
+            - name: containerd-socket
+              mountPath: /run/containerd/containerd.sock
+            {{- end }}
       volumes:
         - name: config-volume
           configMap:
@@ -125,6 +129,12 @@ spec:
                 path: tap-config.yaml
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.integrations.containerd.enabled }}
+        - name: containerd-socket
+          hostPath:
+            path: {{ .Values.integrations.containerd.hostSocketPath }}
+            type: Socket
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/qpoint-tap/values.yaml
+++ b/charts/qpoint-tap/values.yaml
@@ -78,6 +78,10 @@ volumes:
       # Ensure the file directory is created.
       path: /sys
       type: Directory
+  - name: containerdsock
+    hostPath:
+      path: /run/containerd/containerd.sock
+      type: Socket
 
 # Additional volumeMounts on the output Deployment definition.
 volumeMounts:
@@ -87,6 +91,8 @@ volumeMounts:
   - name: sys
     mountPath: "/sys"
     readOnly: true
+  - name: containerdsock
+    mountPath: /run/containerd/containerd.sock
 
 nodeSelector: {}
 

--- a/charts/qpoint-tap/values.yaml
+++ b/charts/qpoint-tap/values.yaml
@@ -78,10 +78,6 @@ volumes:
       # Ensure the file directory is created.
       path: /sys
       type: Directory
-  - name: containerdsock
-    hostPath:
-      path: /run/containerd/containerd.sock
-      type: Socket
 
 # Additional volumeMounts on the output Deployment definition.
 volumeMounts:
@@ -91,14 +87,17 @@ volumeMounts:
   - name: sys
     mountPath: "/sys"
     readOnly: true
-  - name: containerdsock
-    mountPath: /run/containerd/containerd.sock
 
 nodeSelector: {}
 
 tolerations: []
 
 affinity: {}
+
+integrations:
+  containerd:
+    enabled: true
+    hostSocketPath: /run/containerd/containerd.sock
 
 # API token
 registrationToken: ""


### PR DESCRIPTION
### default
`helm template ./charts/qpoint-tap`
```diff
          volumeMounts:
            # ...
            - mountPath: /sys
              name: sys
              readOnly: true
+           - name: containerd-socket
+             mountPath: /run/containerd/containerd.sock
      volumes:
        # ...
        - hostPath:
            path: /sys
            type: Directory
          name: sys
+       - name: containerd-socket
+         hostPath:
+           path: /run/containerd/containerd.sock
+           type: Socket
```

### containerd disabled
`helm template ./charts/qpoint-tap --set integrations.containerd.enabled=false`
```yaml
          volumeMounts:
            # ...
            - mountPath: /sys
              name: sys
              readOnly: true
      volumes:
        # ...
        - hostPath:
            path: /sys
            type: Directory
          name: sys
```

### containerd override host socket path
`helm template ./charts/qpoint-tap --set integrations.containerd.hostSocketPath=/some/other/path`
```diff
          volumeMounts:
            # ...
            - mountPath: /sys
              name: sys
              readOnly: true
+           - name: containerd-socket
+             mountPath: /run/containerd/containerd.sock
      volumes:
        # ...
        - hostPath:
            path: /sys
            type: Directory
          name: sys
+       - name: containerd-socket
+         hostPath:
+           path: /some/other/path
+           type: Socket
```